### PR TITLE
Update data-readiness-levels-short.md

### DIFF
--- a/_data-science/includes/data-readiness-levels-short.md
+++ b/_data-science/includes/data-readiness-levels-short.md
@@ -12,7 +12,7 @@
 
 \notes{[Data Readiness Levels](http://inverseprobability.com/2017/01/12/data-readiness-levels) [@Lawrence:drl17] are an attempt to develop a language around data quality that can bridge the gap between technical solutions and decision makers such as managers and project planners. The are inspired by Technology Readiness Levels which attempt to quantify the readiness of technologies for deployment.}
 
-\notes{See this blog on}\addblog{Data Readiness Levels}{2017/01/12/data-readiness-levels}\notes{.}
+\notes{See this }\addblog{Data Readiness Levels}{2017/01/12/data-readiness-levels}
 
 \include{_data-science/includes/three-grades-of-data-readiness.md}
 


### PR DESCRIPTION
Removed redundant phrase "blog on" as phrase "blog post on "  is included from the macro
Definition of addblog macro used in current compilation,
`\define{\addblog{title}{link}}{blog post on [\title](http://inverseprobability.com/\link).}`

![image](https://user-images.githubusercontent.com/46307971/90315617-6abba100-df3a-11ea-9959-91f77608f425.png)
