### PR TITLE
Fix bias formula in bias-variance-dilemma.md

### DIFF
--- a/_ml/includes/bias-variance-dilemma.md
+++ b/_ml/includes/bias-variance-dilemma.md
@@ -53,7 +53,7 @@ $$
 * Given by}
   $$
   \text{bias}\left[\mappingFunction^*(\inputVector)\right] =
-\mathbb{E}\left[\mappingFunction^*(\inputVector)\right] * \mappingFunction(\inputVector)
+\mathbb{E}\left[\mappingFunction^*(\inputVector)\right] - \mappingFunction(\inputVector)
 $$
 \notes{and it summarizes error that arises from the model's inability to represent the underlying complexity of the data. For example, if we were to model the marathon pace of the winning runner from the Olympics by computing the average pace across time, then that model would exhibit *bias* error because the reality of Olympic marathon pace is it is changing (typically getting faster).}
 


### PR DESCRIPTION
According to http://www.dam.brown.edu/people/geman/Homepage/Essays%20and%20ideas%20about%20neurobiology/bias-variance.pdf and https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff, the bias term is the difference of the expectation of the predictive function and the true function, not their product.

Also, I feel that the derivation given in this document is a bit too terse? I found it helpful on the Wikipedia page to see the dependency of f*(x) on the dataset D spelt out explicitly. What do you think?