### PR TITLE
Add data.set_index("admin1Name_en", inplace=True)

### DIFF
--- a/_datasets/includes/nigerian-administrative-zones-data.md
+++ b/_datasets/includes/nigerian-administrative-zones-data.md
@@ -10,6 +10,7 @@
 \include{_software/includes/pods-software.md}
 
 \code{data = pods.datasets.nigerian_administrative_zones()['Y']
+data.set_index("admin1Name_en", inplace=True)
 data.head()}
 
 \notes{Alternatively you can access the data directly with the following commands.


### PR DESCRIPTION
Without this operation, the `zones_gdf` dataframe does not have the right index, therefore on the `hosp_state_joined = sjoin(hosp_gdf, zones_gdf, how='left')` operation, `hosp_state_joined['right_index']` will not contain the province names, but will only contain random values.