### PR TITLE
Terminology Correction

### DIFF
--- a/_gp/includes/gp-intro-very-short.md
+++ b/_gp/includes/gp-intro-very-short.md
@@ -4,17 +4,17 @@
 
 \notes{\subsection{Bayesian Inference by Rejection Sampling}
 
-One view of Bayesian inference is to assume we are given a mechanism for generating samples, where we assume that mechanism is representing on accurate view on the way we believe the world works. 
+One view of Bayesian inference is to assume we are given a mechanism for generating samples, where we assume that mechanism is representing an accurate view on the way we believe the world works. 
 
 This mechanism is known as our *prior* belief. 
 
-We combine our prior belief with our observations of the real world by discarding all those samples that are inconsistent with our prior. The *likelihood* defines mathematically what we mean by inconsistent with the prior. The higher the noise level in the likelihood, the looser the notion of consistent.
+We combine our prior belief with our observations of the real world by discarding all those prior samples that are inconsistent with our observations. The *likelihood* defines mathematically what we mean by inconsistent with the observations. The higher the noise level in the likelihood, the looser the notion of consistent.
 
 The samples that remain are samples from the *posterior*. 
 
 This approach to Bayesian inference is closely related to two sampling techniques known as *rejection sampling* and *importance sampling*. It is realized in practice in an approach known as *approximate Bayesian computation* (ABC) or likelihood-free inference. 
 
-In practice, the algorithm is often too slow to be practical, because most samples will be inconsistent with the data and as a result the mechanism must be operated many times to obtain a few posterior samples. 
+In practice, the algorithm is often too slow to be practical, because most samples will be inconsistent with the observations and as a result the mechanism must be operated many times to obtain a few posterior samples. 
 
 However, in the Gaussian process case, when the likelihood also assumes Gaussian noise, we can operate this mechanism mathematically, and obtain the posterior density *analytically*. This is the benefit of Gaussian processes.}
 


### PR DESCRIPTION
We use the likelihood to reject samples from the prior based on real-world observations - existing text seemed to suggest the opposite.